### PR TITLE
broke up the test cases for exitTest

### DIFF
--- a/sel-blocksTests/_SelBlocks-TestSuite.html
+++ b/sel-blocksTests/_SelBlocks-TestSuite.html
@@ -24,7 +24,9 @@
 <tr><td><a href="function.html">function</a></td></tr>
 <tr><td><a href="function-recursive.html">function-recursive</a></td></tr>
 <tr><td><a href="issue#2-function.html">issue#2-function</a></td></tr>
-<tr><td><a href="exitTest.html">exitTest</a></td></tr>
+<tr><td><a href="exitTest - exits test.html">exitTest - exits test</a></td></tr>
+<tr><td><a href="exitTest - from within a function.html">exitTest - from within a function</a></td></tr>
+<tr><td><a href="exitTest - from within a loop.html">exitTest - from within a loop</a></td></tr>
 </tbody></table>
 </body>
 </html>

--- a/sel-blocksTests/exitTest - exits test.html
+++ b/sel-blocksTests/exitTest - exits test.html
@@ -26,58 +26,6 @@
 	<td>&quot;shouldn't happen&quot;</td>
 	<td></td>
 </tr>
-<!---- from within a loop-->
-<tr>
-	<td>for</td>
-	<td>i=0; i &lt; 5; i++</td>
-	<td></td>
-</tr>
-<tr>
-	<td>if</td>
-	<td>i == 3</td>
-	<td></td>
-</tr>
-<tr>
-	<td>exitTest</td>
-	<td></td>
-	<td></td>
-</tr>
-<tr>
-	<td>endIf</td>
-	<td></td>
-	<td></td>
-</tr>
-<tr>
-	<td>endFor</td>
-	<td></td>
-	<td></td>
-</tr>
-<!---- from within a function-->
-<tr>
-	<td>call</td>
-	<td>doSubExit</td>
-	<td></td>
-</tr>
-<tr>
-	<td>throw</td>
-	<td>&quot;shouldn't happen&quot;</td>
-	<td></td>
-</tr>
-<tr>
-	<td>function</td>
-	<td>doSubExit</td>
-	<td></td>
-</tr>
-<tr>
-	<td>exitTest</td>
-	<td></td>
-	<td></td>
-</tr>
-<tr>
-	<td>endFunction</td>
-	<td>doSubExit</td>
-	<td></td>
-</tr>
 </tbody></table>
 </body>
 </html>

--- a/sel-blocksTests/exitTest - from within a function.html
+++ b/sel-blocksTests/exitTest - from within a function.html
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head profile="http://selenium-ide.openqa.org/profiles/test-case">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<link rel="selenium.base" href="http://change-this-to-the-site-you-are-testing/" />
+<title>exitTest - from within a function</title>
+</head>
+<body>
+<table cellpadding="1" cellspacing="1" border="1">
+<thead>
+<tr><td rowspan="1" colspan="3">exitTest - from within a function</td></tr>
+</thead><tbody>
+<!---- from within a function-->
+<tr>
+	<td>call</td>
+	<td>doSubExit</td>
+	<td></td>
+</tr>
+<tr>
+	<td>throw</td>
+	<td>&quot;shouldn't happen&quot;</td>
+	<td></td>
+</tr>
+<tr>
+	<td>function</td>
+	<td>doSubExit</td>
+	<td></td>
+</tr>
+<tr>
+	<td>exitTest</td>
+	<td></td>
+	<td></td>
+</tr>
+<tr>
+	<td>endFunction</td>
+	<td>doSubExit</td>
+	<td></td>
+</tr>
+</tbody></table>
+</body>
+</html>

--- a/sel-blocksTests/exitTest - from within a loop.html
+++ b/sel-blocksTests/exitTest - from within a loop.html
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head profile="http://selenium-ide.openqa.org/profiles/test-case">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<link rel="selenium.base" href="http://change-this-to-the-site-you-are-testing/" />
+<title>exitTest - from within a loop</title>
+</head>
+<body>
+<table cellpadding="1" cellspacing="1" border="1">
+<thead>
+<tr><td rowspan="1" colspan="3">exitTest - from within a loop</td></tr>
+</thead><tbody>
+<!---- from within a loop-->
+<tr>
+	<td>for</td>
+	<td>i=0; i &lt; 5; i++</td>
+	<td></td>
+</tr>
+<tr>
+	<td>if</td>
+	<td>i == 3</td>
+	<td></td>
+</tr>
+<tr>
+	<td>exitTest</td>
+	<td></td>
+	<td></td>
+</tr>
+<tr>
+	<td>endIf</td>
+	<td></td>
+	<td></td>
+</tr>
+<tr>
+	<td>endFor</td>
+	<td></td>
+	<td></td>
+</tr>
+<tr>
+	<td>throw</td>
+	<td>&quot;shouldn't happen&quot;</td>
+	<td></td>
+</tr>
+</tbody></table>
+</body>
+</html>


### PR DESCRIPTION
fixes issue #14 

After the first successful command to exitTest, the test exits and none
of the other cases were tested. Breaking up the tests and putting a
failure condition in after the call to exitTest fixes false passes.